### PR TITLE
manifests-gen outputs to profile directory

### DIFF
--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -222,7 +222,7 @@ func main() {
 
 	containerImageRefs := slices.Collect(maps.Values(containerImages))
 
-	providerImages, err := providerimages.ReadProviderImages(context.Background(), mgr.GetAPIReader(), mgr.GetLogger(), containerImageRefs, providerImageDir)
+	providerProfiles, err := providerimages.ReadProviderImages(context.Background(), mgr.GetAPIReader(), mgr.GetLogger(), containerImageRefs, providerImageDir)
 	if err != nil {
 		klog.Error(err, "unable to get provider image metadata")
 		os.Exit(1)
@@ -240,7 +240,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupPlatformReconcilers(mgr, infra, platform, containerImages, providerImages, applyClient, apiextensionsClient, *managedNamespace)
+	setupPlatformReconcilers(mgr, infra, platform, containerImages, providerProfiles, applyClient, apiextensionsClient, *managedNamespace)
 
 	// +kubebuilder:scaffold:builder
 
@@ -272,18 +272,17 @@ func getClusterOperatorStatusClient(mgr manager.Manager, controller string, plat
 	}
 }
 
-// TODO: should we rename providerImages arg to providerImagesManifests ?
-func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platform configv1.PlatformType, containerImages map[string]string, providerImages []providerimages.ProviderImageManifests, applyClient *kubernetes.Clientset, apiextensionsClient *apiextensionsclient.Clientset, managedNamespace string) {
+func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platform configv1.PlatformType, containerImages map[string]string, providerProfiles []providerimages.ProviderImageManifests, applyClient *kubernetes.Clientset, apiextensionsClient *apiextensionsclient.Clientset, managedNamespace string) {
 	// Only setup reconcile controllers and webhooks when the platform is supported.
 	// This avoids unnecessary CAPI providers discovery, installs and reconciles when the platform is not supported.
 	isUnsupportedPlatform := false
 
 	switch platform {
 	case configv1.AWSPlatformType:
-		setupReconcilers(mgr, infra, platform, &awsv1.AWSCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &awsv1.AWSCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	case configv1.GCPPlatformType:
-		setupReconcilers(mgr, infra, platform, &gcpv1.GCPCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &gcpv1.GCPCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	case configv1.AzurePlatformType:
 		azureCloudEnvironment := getAzureCloudEnvironment(infra.Status.PlatformStatus)
@@ -293,20 +292,20 @@ func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructur
 			isUnsupportedPlatform = true
 		} else {
 			// The ClusterOperator Controller must run in all cases.
-			setupReconcilers(mgr, infra, platform, &azurev1.AzureCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+			setupReconcilers(mgr, infra, platform, &azurev1.AzureCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 			setupWebhooks(mgr)
 		}
 	case configv1.PowerVSPlatformType:
-		setupReconcilers(mgr, infra, platform, &ibmpowervsv1.IBMPowerVSCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &ibmpowervsv1.IBMPowerVSCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	case configv1.VSpherePlatformType:
-		setupReconcilers(mgr, infra, platform, &vspherev1.VSphereCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &vspherev1.VSphereCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	case configv1.OpenStackPlatformType:
-		setupReconcilers(mgr, infra, platform, &openstackv1.OpenStackCluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &openstackv1.OpenStackCluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	case configv1.BareMetalPlatformType:
-		setupReconcilers(mgr, infra, platform, &metal3v1.Metal3Cluster{}, containerImages, providerImages, applyClient, apiextensionsClient, managedNamespace)
+		setupReconcilers(mgr, infra, platform, &metal3v1.Metal3Cluster{}, containerImages, providerProfiles, applyClient, apiextensionsClient, managedNamespace)
 		setupWebhooks(mgr)
 	default:
 		klog.Infof("Detected platform %q is not supported, skipping capi controllers setup", platform)
@@ -318,7 +317,7 @@ func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructur
 	setupClusterOperatorController(mgr, platform, managedNamespace, isUnsupportedPlatform)
 }
 
-func setupReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platform configv1.PlatformType, infraClusterObject client.Object, containerImages map[string]string, providerImages []providerimages.ProviderImageManifests, applyClient *kubernetes.Clientset, apiextensionsClient *apiextensionsclient.Clientset, managedNamespace string) {
+func setupReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platform configv1.PlatformType, infraClusterObject client.Object, containerImages map[string]string, providerProfiles []providerimages.ProviderImageManifests, applyClient *kubernetes.Clientset, apiextensionsClient *apiextensionsclient.Clientset, managedNamespace string) {
 	if err := (&corecluster.CoreClusterController{
 		ClusterOperatorStatusClient: getClusterOperatorStatusClient(mgr, "cluster-capi-operator-cluster-resource-controller", platform, managedNamespace),
 		Cluster:                     &clusterv1.Cluster{},
@@ -354,7 +353,7 @@ func setupReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platf
 		Platform:                    platform,
 		ApplyClient:                 applyClient,
 		APIExtensionsClient:         apiextensionsClient,
-		ProviderImages:              providerImages,
+		ProviderImages:              providerProfiles,
 	}).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "unable to create capi installer controller", "controller", "CAPIInstaller")
 		os.Exit(1)

--- a/cmd/cluster-capi-operator/main.go
+++ b/cmd/cluster-capi-operator/main.go
@@ -272,6 +272,7 @@ func getClusterOperatorStatusClient(mgr manager.Manager, controller string, plat
 	}
 }
 
+// TODO: should we rename providerImages arg to providerImagesManifests ?
 func setupPlatformReconcilers(mgr manager.Manager, infra *configv1.Infrastructure, platform configv1.PlatformType, containerImages map[string]string, providerImages []providerimages.ProviderImageManifests, applyClient *kubernetes.Clientset, apiextensionsClient *apiextensionsclient.Clientset, managedNamespace string) {
 	// Only setup reconcile controllers and webhooks when the platform is supported.
 	// This avoids unnecessary CAPI providers discovery, installs and reconciles when the platform is not supported.

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -37,7 +37,13 @@ func generateManifests(opts cmdlineOptions) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to genereate kustomize resources: %w", err)
+		return fmt.Errorf("failed to generate kustomize resources: %w", err)
+	}
+
+	// Create output directory for profile
+	profileDir := path.Join(opts.manifestsPath, opts.profileName)
+	if err := os.MkdirAll(profileDir, os.ModeDir|0755); err != nil {
+		return fmt.Errorf("error creating profile directory %s: %w", profileDir, err)
 	}
 
 	// Perform all manifest transformations
@@ -96,14 +102,7 @@ func generateKustomizeResources(kustomizeDir string) ([]client.Object, error) {
 }
 
 func writeManifests(opts cmdlineOptions, resources []client.Object) (err error) {
-	manifestsDir := path.Join(opts.manifestsPath, opts.profileName)
-
-	err = os.MkdirAll(manifestsDir, os.ModeDir|0755)
-	if err != nil {
-		return fmt.Errorf("error creating metadata directory %s: %w", manifestsDir, err)
-	}
-
-	manifestsPathname := path.Join(manifestsDir, manifestsFilename)
+	manifestsPathname := path.Join(opts.manifestsPath, opts.profileName, manifestsFilename)
 
 	manifestsFile, err := os.OpenFile(manifestsPathname, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -138,14 +137,7 @@ func writeManifests(opts cmdlineOptions, resources []client.Object) (err error) 
 }
 
 func writeMetadata(opts cmdlineOptions) (err error) {
-	metadataDir := path.Join(opts.manifestsPath, opts.profileName)
-
-	err = os.MkdirAll(metadataDir, os.ModeDir|0755)
-	if err != nil {
-		return fmt.Errorf("error creating metadata directory %s: %w", metadataDir, err)
-	}
-
-	metadataPathname := path.Join(metadataDir, metadataFilename)
+	metadataPathname := path.Join(opts.manifestsPath, opts.profileName, metadataFilename)
 
 	metadataFile, err := os.OpenFile(metadataPathname, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -24,7 +24,7 @@ const (
 	// metadataFilename is the name of the file containing provider metadata.
 	metadataFilename = "metadata.yaml"
 
-	// capiNamespace is the namespace where capi components are created
+	// capiNamespace is the namespace where capi components are created.
 	capiNamespace = "openshift-cluster-api"
 )
 
@@ -33,8 +33,9 @@ func generateManifests(opts cmdlineOptions) error {
 
 	kustomizeDir := path.Join(opts.basePath, opts.kustomizeDir)
 	resources, err := generateKustomizeResources(kustomizeDir)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to genereate kustomize resources: %w", err)
 	}
 
 	// Perform all manifest transformations
@@ -56,7 +57,7 @@ func generateManifests(opts cmdlineOptions) error {
 	return nil
 }
 
-// generateKustomizeResources generates resources from a kustomize directory
+// generateKustomizeResources generates resources from a kustomize directory.
 func generateKustomizeResources(kustomizeDir string) ([]client.Object, error) {
 	// Compile assets using kustomize.
 	fmt.Printf("> Generating OpenShift manifests based on kustomize.yaml from %q\n", kustomizeDir)
@@ -93,7 +94,14 @@ func generateKustomizeResources(kustomizeDir string) ([]client.Object, error) {
 }
 
 func writeManifests(opts cmdlineOptions, resources []client.Object) (err error) {
-	manifestsPathname := path.Join(opts.manifestsPath, manifestsFilename)
+	manifestsDir := path.Join(opts.manifestsPath, opts.profileName)
+
+	err = os.MkdirAll(manifestsDir, os.ModeDir|0755)
+	if err != nil {
+		return fmt.Errorf("error creating metadata directory %s: %w", manifestsDir, err)
+	}
+
+	manifestsPathname := path.Join(manifestsDir, manifestsFilename)
 
 	manifestsFile, err := os.OpenFile(manifestsPathname, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -128,7 +136,14 @@ func writeManifests(opts cmdlineOptions, resources []client.Object) (err error) 
 }
 
 func writeMetadata(opts cmdlineOptions) (err error) {
-	metadataPathname := path.Join(opts.manifestsPath, metadataFilename)
+	metadataDir := path.Join(opts.manifestsPath, opts.profileName)
+
+	err = os.MkdirAll(metadataDir, os.ModeDir|0755)
+	if err != nil {
+		return fmt.Errorf("error creating metadata directory %s: %w", metadataDir, err)
+	}
+
+	metadataPathname := path.Join(metadataDir, metadataFilename)
 
 	metadataFile, err := os.OpenFile(metadataPathname, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {

--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -31,8 +31,10 @@ const (
 func generateManifests(opts cmdlineOptions) error {
 	fmt.Printf("Processing provider %s\n", opts.name)
 
-	kustomizeDir := path.Join(opts.basePath, opts.kustomizeDir)
-	resources, err := generateKustomizeResources(kustomizeDir)
+	resources, err := generateKustomizeResources(opts.kustomizeDir)
+	if err != nil {
+		return fmt.Errorf("failed to generate kustomize resources: %w", err)
+	}
 
 	if err != nil {
 		return fmt.Errorf("failed to genereate kustomize resources: %w", err)

--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -59,6 +59,7 @@ func init() {
 type cmdlineOptions struct {
 	basePath               string
 	manifestsPath          string
+	profileName            string
 	kustomizeDir           string
 	name                   string
 	providerType           string
@@ -72,6 +73,7 @@ func main() {
 	var (
 		basePath      = flag.String("base-path", "", "Path to the root of the provider's repository. Required.")
 		manifestsPath = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
+		profileName   = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
 		kustomizeDir  = flag.String("kustomize-dir", defaultKustomizeComponentsPath, "Directory containing kustomization.yaml file used to generate the base resources, relative to the base-path (default: ./config/default)")
 
 		providerName    = flag.String("provider-name", "", "Name of the provider, e.g. 'cluster-api-provider-aws'. Required.")
@@ -88,6 +90,7 @@ func main() {
 	opts := cmdlineOptions{
 		basePath:               *basePath,
 		manifestsPath:          *manifestsPath,
+		profileName:            *profileName,
 		kustomizeDir:           *kustomizeDir,
 		name:                   *providerName,
 		providerType:           *providerType,

--- a/manifests-gen/main.go
+++ b/manifests-gen/main.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	defaultKustomizeComponentsPath = "./config/default"
-
 	providerTypeCore           = "core"
 	providerTypeInfrastructure = "infrastructure"
 )
@@ -57,7 +55,6 @@ func init() {
 }
 
 type cmdlineOptions struct {
-	basePath               string
 	manifestsPath          string
 	profileName            string
 	kustomizeDir           string
@@ -71,10 +68,9 @@ type cmdlineOptions struct {
 
 func main() {
 	var (
-		basePath      = flag.String("base-path", "", "Path to the root of the provider's repository. Required.")
 		manifestsPath = flag.String("manifests-path", "", "Path to the desired directory where to output the generated manifests. Required.")
 		profileName   = flag.String("profile-name", "default", "Name of the profile, e.g 'featuregate-foo' (default: 'default'.'")
-		kustomizeDir  = flag.String("kustomize-dir", defaultKustomizeComponentsPath, "Directory containing kustomization.yaml file used to generate the base resources, relative to the base-path (default: ./config/default)")
+		kustomizeDir  = flag.String("kustomize-dir", "", "Directory containing kustomization.yaml file used to generate the base resources, relative to the current working directory. Required.")
 
 		providerName    = flag.String("provider-name", "", "Name of the provider, e.g. 'cluster-api-provider-aws'. Required.")
 		providerType    = flag.String("provider-type", "", "Type of the provider: core or infrastructure. Optional.")
@@ -88,7 +84,6 @@ func main() {
 	flag.Parse()
 
 	opts := cmdlineOptions{
-		basePath:               *basePath,
 		manifestsPath:          *manifestsPath,
 		profileName:            *profileName,
 		kustomizeDir:           *kustomizeDir,
@@ -113,7 +108,7 @@ func main() {
 
 func validateFlags(opts cmdlineOptions) error {
 	return errors.Join(
-		hasValue("base path", opts.basePath),
+		hasValue("kustomize directory", opts.kustomizeDir),
 		hasValue("manifests path", opts.manifestsPath),
 		hasValue("provider name", opts.name),
 

--- a/pkg/providerimages/providerimages.go
+++ b/pkg/providerimages/providerimages.go
@@ -58,6 +58,7 @@ type ProviderImageManifests struct {
 	Type          string
 	Version       string
 	OCPPlatform   configv1.PlatformType
+	Profile       string
 	ContentID     string
 	ManifestsPath string
 }
@@ -132,7 +133,7 @@ func ReadProviderImages(ctx context.Context, k8sClient client.Reader, log logr.L
 
 type providerImageResult struct {
 	imageRef  string
-	manifests *ProviderImageManifests
+	manifests []ProviderImageManifests
 	err       error
 }
 
@@ -168,14 +169,17 @@ func readProviderImages(ctx context.Context, log logr.Logger, containerImages []
 	for result := range results {
 		if result.err != nil {
 			err = errors.Join(err, fmt.Errorf("fetching provider from image %s: %w", result.imageRef, result.err))
-		} else if result.manifests != nil {
-			log.Info("found provider manifests in container image", "image", result.imageRef,
-				"provider", result.manifests.Name,
-				"type", result.manifests.Type,
-				"version", result.manifests.Version,
-				"ocpPlatform", result.manifests.OCPPlatform)
+		} else {
+			for _, manifest := range result.manifests {
+				log.Info("found provider manifests in container image", "image", result.imageRef,
+					"provider", manifest.Name,
+					"type", manifest.Type,
+					"version", manifest.Version,
+					"profile", manifest.Profile,
+					"ocpPlatform", manifest.OCPPlatform)
 
-			providerImages = append(providerImages, *result.manifests)
+				providerImages = append(providerImages, manifest)
+			}
 		}
 	}
 
@@ -188,7 +192,7 @@ func readProviderImages(ctx context.Context, log logr.Logger, containerImages []
 	return providerImages, nil
 }
 
-func processProviderImage(ctx context.Context, imageRef, providerImageDir string, fetcher imageFetcher) (*ProviderImageManifests, error) {
+func processProviderImage(ctx context.Context, imageRef, providerImageDir string, fetcher imageFetcher) ([]ProviderImageManifests, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
@@ -199,19 +203,7 @@ func processProviderImage(ctx context.Context, imageRef, providerImageDir string
 		return nil, fmt.Errorf("failed to fetch image %s: %w", imageRef, err)
 	}
 
-	// Extract files from the image
-	metadata, manifestsContent, err := extractCapiManifests(img)
-	if err != nil {
-		if errors.Is(err, errNoCapiManifests) {
-			// Image doesn't contain /capi-manifests, skip it
-			return nil, nil //nolint:nilnil // intentional: nil manifest with no error means skip this image
-		}
-
-		return nil, err
-	}
-
-	// Create output directory for this provider
-	// Use a sanitized version of the image reference as the subdirectory name
+	// Create output directory for this provider image
 	sanitizedRef := sanitizeImageRef(imageRef)
 	outputDir := filepath.Join(providerImageDir, sanitizedRef)
 
@@ -219,22 +211,46 @@ func processProviderImage(ctx context.Context, imageRef, providerImageDir string
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	// Write manifests to the cache directory, performing image substitution and hash calculation
-	manifestsPath := filepath.Join(outputDir, manifestsFile)
-
-	contentID, err := writeManifestsWithHash(manifestsPath, manifestsContent, metadata.ProviderImageRef, imageRef)
-	if err != nil {
+	// Extract files from the image to disk
+	if err := extractCapiManifestsToDir(img, outputDir); err != nil {
 		return nil, err
 	}
 
-	return &ProviderImageManifests{
-		Name:          metadata.ProviderName,
-		Type:          metadata.ProviderType,
-		Version:       metadata.ProviderVersion,
-		OCPPlatform:   metadata.OCPPlatform,
-		ContentID:     contentID,
-		ManifestsPath: manifestsPath,
-	}, nil
+	// Discover profiles from extracted files
+	profiles, err := discoverProfiles(outputDir)
+	if err != nil {
+		if errors.Is(err, errNoCapiManifests) {
+			// Image doesn't contain /capi-operator-manifests, skip it
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	// Process each profile
+	results := make([]ProviderImageManifests, 0, len(profiles))
+
+	for _, profile := range profiles {
+		profileDir := filepath.Join(outputDir, profile.Profile)
+		manifestsPath := filepath.Join(profileDir, manifestsFile)
+
+		contentID, err := writeManifestsWithHash(manifestsPath, profile.Manifests, profile.Metadata.ProviderImageRef, imageRef)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, ProviderImageManifests{
+			Name:          profile.Metadata.ProviderName,
+			Type:          profile.Metadata.ProviderType,
+			Version:       profile.Metadata.ProviderVersion,
+			OCPPlatform:   profile.Metadata.OCPPlatform,
+			Profile:       profile.Profile,
+			ContentID:     contentID,
+			ManifestsPath: manifestsPath,
+		})
+	}
+
+	return results, nil
 }
 
 var (
@@ -243,76 +259,138 @@ var (
 	errMissingManifests = errors.New("missing manifests.yaml in /capi-operator-manifests")
 )
 
-func extractCapiManifests(img v1.Image) (*ProviderMetadata, string, error) {
-	layers, err := img.Layers()
+// profileManifests holds parsed metadata and manifest content for a single profile.
+type profileManifests struct {
+	Profile   string
+	Metadata  *ProviderMetadata
+	Manifests string
+}
+
+// discoverProfiles scans a directory for valid profiles.
+// Each subdirectory must contain both metadata.yaml and manifests.yaml.
+// Returns an error if no profiles are found or if any profile is incomplete.
+func discoverProfiles(dir string) ([]profileManifests, error) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get image layers: %w", err)
+		if os.IsNotExist(err) {
+			return nil, errNoCapiManifests
+		}
+
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
 	}
 
-	var metadataContent, manifestsContent string
-	// Use path (not filepath) since tar always uses forward slashes
-	metadataPath := path.Join(capiManifestsDir, metadataFile)
-	manifestsPath := path.Join(capiManifestsDir, manifestsFile)
+	var profiles []profileManifests
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		profileName := entry.Name()
+		profileDir := filepath.Join(dir, profileName)
+
+		profile, isProfile, err := loadProfile(profileName, profileDir)
+		if err != nil {
+			return nil, err
+		}
+
+		if isProfile {
+			profiles = append(profiles, *profile)
+		}
+	}
+
+	if len(profiles) == 0 {
+		return nil, errNoCapiManifests
+	}
+
+	return profiles, nil
+}
+
+// loadProfile loads a single profile from a directory.
+// Returns isProfile=false if the directory is not a profile (no metadata.yaml or manifests.yaml).
+// Returns an error if the profile is incomplete (has one file but not the other).
+func loadProfile(profileName, profileDir string) (profile *profileManifests, isProfile bool, err error) {
+	metadataPath := filepath.Join(profileDir, metadataFile)
+	manifestsPath := filepath.Join(profileDir, manifestsFile)
+
+	metadataInfo, metadataErr := os.Stat(metadataPath)
+	manifestsInfo, manifestsErr := os.Stat(manifestsPath)
+
+	metadataExists := metadataErr == nil && !metadataInfo.IsDir()
+	manifestsExists := manifestsErr == nil && !manifestsInfo.IsDir()
+
+	if !metadataExists && !manifestsExists {
+		return nil, false, nil
+	}
+
+	if !metadataExists {
+		return nil, false, fmt.Errorf("profile %s: %w", profileName, errMissingMetadata)
+	}
+
+	if !manifestsExists {
+		return nil, false, fmt.Errorf("profile %s: %w", profileName, errMissingManifests)
+	}
+
+	metadataContent, err := os.ReadFile(metadataPath) //nolint:gosec // path constructed from trusted input
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read metadata for profile %s: %w", profileName, err)
+	}
+
+	manifestsContent, err := os.ReadFile(manifestsPath) //nolint:gosec // path constructed from trusted input
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read manifests for profile %s: %w", profileName, err)
+	}
+
+	var metadata ProviderMetadata
+	if err := yaml.Unmarshal(metadataContent, &metadata); err != nil {
+		return nil, false, fmt.Errorf("failed to parse metadata.yaml for profile %s: %w", profileName, err)
+	}
+
+	return &profileManifests{
+		Profile:   profileName,
+		Metadata:  &metadata,
+		Manifests: string(manifestsContent),
+	}, true, nil
+}
+
+// extractCapiManifestsToDir extracts all files under /capi-operator-manifests from the
+// image to destDir. Iterates layers top to bottom so higher layers take precedence.
+func extractCapiManifestsToDir(img v1.Image, destDir string) error {
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("failed to get image layers: %w", err)
+	}
 
 	// Iterate layers in reverse order (top to bottom) since higher layers
-	// overwrite files from lower layers in OCI images
+	// take precedence. extractFilesToDir skips files that already exist.
 	for i := len(layers) - 1; i >= 0; i-- {
 		layer := layers[i]
 
 		rc, err := layer.Uncompressed()
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to uncompress layer: %w", err)
+			return fmt.Errorf("failed to uncompress layer: %w", err)
 		}
 
-		found, err := extractFilesFromTar(rc, metadataPath, manifestsPath)
+		err = extractFilesToDir(rc, capiManifestsDir, destDir)
 
 		err = errors.Join(err, rc.Close())
 		if err != nil {
-			return nil, "", err
-		}
-
-		if content, ok := found[metadataPath]; ok {
-			metadataContent = content
-		}
-
-		if content, ok := found[manifestsPath]; ok {
-			manifestsContent = content
-		}
-
-		// Early exit once both files are found
-		if metadataContent != "" && manifestsContent != "" {
-			break
+			return err
 		}
 	}
 
-	if metadataContent == "" && manifestsContent == "" {
-		return nil, "", errNoCapiManifests
-	}
-
-	if metadataContent == "" {
-		return nil, "", errMissingMetadata
-	}
-
-	if manifestsContent == "" {
-		return nil, "", errMissingManifests
-	}
-
-	var metadata ProviderMetadata
-	if err := yaml.Unmarshal([]byte(metadataContent), &metadata); err != nil {
-		return nil, "", fmt.Errorf("failed to parse metadata.yaml: %w", err)
-	}
-
-	return &metadata, manifestsContent, nil
+	return nil
 }
 
-func extractFilesFromTar(r io.Reader, paths ...string) (map[string]string, error) {
+// extractFilesToDir extracts all files under prefix from a tar stream to destDir.
+// Files are written preserving their relative path under the prefix.
+// e.g., prefix="/capi-operator-manifests", file="/capi-operator-manifests/default/foo.yaml"
+// → written to destDir/default/foo.yaml
+// Files that already exist are skipped (caller iterates layers top to bottom).
+func extractFilesToDir(r io.Reader, prefix, destDir string) error {
 	tr := tar.NewReader(r)
-	results := make(map[string]string)
-
-	pathSet := make(map[string]struct{}, len(paths))
-	for _, p := range paths {
-		pathSet[p] = struct{}{}
-	}
+	// Ensure prefix has leading slash and no trailing slash for consistent matching
+	prefix = path.Clean("/" + prefix)
 
 	for {
 		header, err := tr.Next()
@@ -321,29 +399,62 @@ func extractFilesFromTar(r io.Reader, paths ...string) (map[string]string, error
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to read tar: %w", err)
+			return fmt.Errorf("failed to read tar: %w", err)
+		}
+
+		// Directory entries in tar are just markers with no content.
+		// We create directories on-demand when writing files.
+		if header.Typeflag == tar.TypeDir {
+			continue
 		}
 
 		// Normalize the path (remove leading ./ or /)
 		// Use path (not filepath) since tar always uses forward slashes
 		normalized := path.Clean("/" + header.Name)
 
-		if _, want := pathSet[normalized]; want {
-			content, err := io.ReadAll(tr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read file %s: %w", normalized, err)
-			}
+		// Check if file is under our prefix
+		if !strings.HasPrefix(normalized, prefix+"/") {
+			continue
+		}
 
-			results[normalized] = string(content)
+		// Get relative path under prefix
+		relPath := strings.TrimPrefix(normalized, prefix+"/")
 
-			// Early exit if all files found
-			if len(results) == len(paths) {
-				break
-			}
+		// Write file to destination
+		destPath := filepath.Join(destDir, relPath)
+
+		// Skip if file already exists (higher layer already wrote it)
+		if _, err := os.Stat(destPath); err == nil {
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), 0750); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+		}
+
+		if err := writeFileFromTar(tr, destPath); err != nil {
+			return fmt.Errorf("failed to write %s: %w", destPath, err)
 		}
 	}
 
-	return results, nil
+	return nil
+}
+
+func writeFileFromTar(tr *tar.Reader, destPath string) (err error) {
+	f, err := os.Create(destPath) //nolint:gosec // path is constructed internally
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+
+	defer func() {
+		err = errors.Join(err, f.Close())
+	}()
+
+	if _, err := io.Copy(f, tr); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
 }
 
 func sanitizeImageRef(imageRef string) string {

--- a/pkg/providerimages/providerimages_test.go
+++ b/pkg/providerimages/providerimages_test.go
@@ -125,11 +125,12 @@ func createTestImageWithLayers(layers []map[string]string) (v1.Image, error) {
 // Test path constants derived from production constants.
 // Tar paths don't use leading slashes, so we use capiManifestsDirName directly.
 const (
-	testMetadataPath  = capiManifestsDirName + "/" + metadataFile
-	testManifestsPath = capiManifestsDirName + "/" + manifestsFile
+	testDefaultProfile = "default"
+	testMetadataPath   = capiManifestsDirName + "/" + testDefaultProfile + "/" + metadataFile
+	testManifestsPath  = capiManifestsDirName + "/" + testDefaultProfile + "/" + manifestsFile
 )
 
-// createCapiManifestsImage creates a test image with metadata and manifests in the capi-operator-manifests directory.
+// createCapiManifestsImage creates a test image with metadata and manifests in a profile subdirectory.
 func createCapiManifestsImage(metadataContent, manifestsContent string) (v1.Image, error) {
 	return createTestImage(map[string]string{
 		testMetadataPath:  metadataContent,
@@ -161,7 +162,7 @@ providerImageRef: %s
 `, providerName, providerType, version, ocpPlatform, providerImageRef)
 }
 
-//nolint:gocognit,funlen
+//nolint:gocognit,funlen,cyclop
 func Test_readProviderImages(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -202,8 +203,9 @@ func Test_readProviderImages(t *testing.T) {
 				g.Expect(manifest.Type).To(Equal("infrastructure"))
 				g.Expect(manifest.Version).To(Equal("v1.0.0"))
 				g.Expect(manifest.OCPPlatform).To(BeEquivalentTo("aws"))
+				g.Expect(manifest.Profile).To(Equal(testDefaultProfile))
 				g.Expect(manifest.ContentID).To(HaveLen(64)) // sha256 hex string
-				g.Expect(manifest.ManifestsPath).To(ContainSubstring("manifests.yaml"))
+				g.Expect(manifest.ManifestsPath).To(ContainSubstring(testDefaultProfile + "/" + manifestsFile))
 
 				// Verify file was written
 				content, err := os.ReadFile(manifest.ManifestsPath)
@@ -528,6 +530,80 @@ contentID: id
 				g.Expect(string(content)).To(Equal("content: from-higher-layer\n"))
 			},
 		},
+		{
+			name: "multiple profiles in one image",
+			containerImages: []string{
+				"registry.example.com/multi-profile:v1.0.0",
+			},
+			setupFetcher: func(t *testing.T) *fakeImageFetcher {
+				t.Helper()
+				img, err := createTestImage(map[string]string{
+					capiManifestsDirName + "/default/metadata.yaml":      createMetadataYAML("aws", "infrastructure", "v1.0.0", "aws", ""),
+					capiManifestsDirName + "/default/manifests.yaml":     "kind: ConfigMap\nname: default-config\n",
+					capiManifestsDirName + "/techpreview/metadata.yaml":  createMetadataYAML("aws", "infrastructure", "v1.0.0-techpreview", "aws", ""),
+					capiManifestsDirName + "/techpreview/manifests.yaml": "kind: ConfigMap\nname: techpreview-config\n",
+				})
+				if err != nil {
+					t.Fatalf("failed to create test image: %v", err)
+				}
+
+				return &fakeImageFetcher{
+					images: map[string]v1.Image{
+						"registry.example.com/multi-profile:v1.0.0": img,
+					},
+				}
+			},
+			validate: func(t *testing.T, g Gomega, result []ProviderImageManifests, outputDir string) {
+				t.Helper()
+				g.Expect(result).To(HaveLen(2))
+
+				profiles := make(map[string]ProviderImageManifests)
+				for _, m := range result {
+					profiles[m.Profile] = m
+				}
+
+				g.Expect(profiles).To(HaveKey("default"))
+				g.Expect(profiles).To(HaveKey("techpreview"))
+				g.Expect(profiles["default"].Version).To(Equal("v1.0.0"))
+				g.Expect(profiles["techpreview"].Version).To(Equal("v1.0.0-techpreview"))
+
+				defaultContent, err := os.ReadFile(profiles["default"].ManifestsPath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(defaultContent)).To(ContainSubstring("default-config"))
+
+				techpreviewContent, err := os.ReadFile(profiles["techpreview"].ManifestsPath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(techpreviewContent)).To(ContainSubstring("techpreview-config"))
+			},
+		},
+		{
+			name: "non-profile subdirectory skipped",
+			containerImages: []string{
+				"registry.example.com/with-random-subdir:v1.0.0",
+			},
+			setupFetcher: func(t *testing.T) *fakeImageFetcher {
+				t.Helper()
+				img, err := createTestImage(map[string]string{
+					capiManifestsDirName + "/default/metadata.yaml":  createMetadataYAML("aws", "infrastructure", "v1.0.0", "aws", ""),
+					capiManifestsDirName + "/default/manifests.yaml": "kind: ConfigMap\n",
+					capiManifestsDirName + "/randomdir/somefile.txt": "this is not a profile",
+				})
+				if err != nil {
+					t.Fatalf("failed to create test image: %v", err)
+				}
+
+				return &fakeImageFetcher{
+					images: map[string]v1.Image{
+						"registry.example.com/with-random-subdir:v1.0.0": img,
+					},
+				}
+			},
+			validate: func(t *testing.T, g Gomega, result []ProviderImageManifests, outputDir string) {
+				t.Helper()
+				g.Expect(result).To(HaveLen(1))
+				g.Expect(result[0].Profile).To(Equal("default"))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -560,23 +636,26 @@ contentID: id
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Verify output directory structure for all successful results
-			// 1. Each manifest's directory should correspond to a containerImage
-			usedDirs := make(map[string]bool)
+			// 1. Each manifest's profile directory should correspond to a containerImage + profile
+			usedProfileDirs := make(map[string]bool)
 
 			for _, manifest := range result {
-				manifestDir := filepath.Dir(manifest.ManifestsPath)
+				// ManifestsPath is now outputDir/imageRef/profile/manifests.yaml
+				profileDir := filepath.Dir(manifest.ManifestsPath)
+				imageDir := filepath.Dir(profileDir)
 
 				// Find a containerImage that would produce this directory
 				found := false
 
 				for _, imageRef := range tt.containerImages {
 					expectedDir := filepath.Join(tmpDir, sanitizeImageRef(imageRef))
-					if manifestDir == expectedDir {
-						// Ensure we don't have duplicate directories (each image produces unique output)
-						g.Expect(usedDirs[expectedDir]).To(BeFalse(),
-							"directory %s was used by multiple manifests", expectedDir)
+					if imageDir == expectedDir {
+						// Ensure we don't have duplicate profile directories
+						// (each image+profile combination produces unique output)
+						g.Expect(usedProfileDirs[profileDir]).To(BeFalse(),
+							"profile directory %s was used by multiple manifests", profileDir)
 
-						usedDirs[expectedDir] = true
+						usedProfileDirs[profileDir] = true
 						found = true
 
 						break
@@ -584,7 +663,7 @@ contentID: id
 				}
 
 				g.Expect(found).To(BeTrue(),
-					"manifest directory %s does not correspond to any containerImage", manifestDir)
+					"manifest directory %s does not correspond to any containerImage", imageDir)
 
 				// 2. Verify the manifest file exists and is readable
 				_, err := os.Stat(manifest.ManifestsPath)


### PR DESCRIPTION
dc7a1221d035e31df6ea6452f83135fcb693601d manifests-gen outputs to profile directory

    Adds a flag, 'profile-name' allowing specification of a profile (and
    therefore subdirectory) to output manifests and metadata to.

57c1f0a3724cd5db77d0c034f8a93df09aacbca4 capi installer now knows about manifest profiles: 

    When parsing images, the logic now checks for multiple 'profiles' (sub
    directories) under `/capi-operator-manifests`.

    If multiple are found, we return them all.


