### PR TITLE
Updates manifests metadata format

### DIFF
--- a/manifests-gen/generate.go
+++ b/manifests-gen/generate.go
@@ -148,11 +148,11 @@ func writeMetadata(opts cmdlineOptions) (err error) {
 	}()
 
 	metadata := providerimages.ProviderMetadata{
-		ProviderName:     opts.name,
-		ProviderType:     opts.providerType,
-		ProviderVersion:  opts.version,
-		OCPPlatform:      configv1.PlatformType(opts.platform),
-		ProviderImageRef: opts.providerImageRef,
+		Name:         opts.name,
+		SelfImageRef: opts.selfImageRef,
+		OCPPlatform:  configv1.PlatformType(opts.platform),
+		InstallOrder: opts.installOrder,
+		Attributes:   opts.attributes,
 	}
 
 	data, err := yaml.Marshal(metadata)

--- a/pkg/controllers/capiinstaller/capi_installer_controller.go
+++ b/pkg/controllers/capiinstaller/capi_installer_controller.go
@@ -196,47 +196,38 @@ func (r *CapiInstallerController) reconcileProviderImages(ctx context.Context, l
 			providerImages = append(providerImages, providerImage)
 
 		default:
-			log.Info("skipping provider image", "name", providerImage.ProviderName)
+			log.Info("skipping provider image", "name", providerImage.Name)
 			continue
 		}
 	}
 
-	// Sort providers by type
-	getTypePriority := func(providerImage providerimages.ProviderImageManifests) int {
-		switch providerImage.ProviderType {
-		case "core":
-			return 0
-		case "infrastructure":
-			return 1
-		default:
-			return 2
-		}
-	}
-
-	slices.SortStableFunc(providerImages, func(a, b providerimages.ProviderImageManifests) int {
-		prioA := getTypePriority(a)
-		prioB := getTypePriority(b)
-
-		if prioA == prioB {
-			return strings.Compare(a.ProviderName, b.ProviderName)
-		}
-
-		return cmp.Compare(prioA, prioB)
-	})
+	// Sort providers by InstallOrder (ascending), then by Name for stability
+	sortProvidersByInstallOrder(providerImages)
 
 	// Apply the provider manifests
 	for _, providerImage := range providerImages {
 		if err := r.applyProviderImage(ctx, log, providerImage); err != nil {
-			return fmt.Errorf("failed to apply provider image %s: %w", providerImage.ProviderName, err)
+			return fmt.Errorf("failed to apply provider image %s: %w", providerImage.Name, err)
 		}
 	}
 
 	return nil
 }
 
+// sortProvidersByInstallOrder sorts providers by InstallOrder ascending, then by Name for stability.
+func sortProvidersByInstallOrder(providers []providerimages.ProviderImageManifests) {
+	slices.SortStableFunc(providers, func(a, b providerimages.ProviderImageManifests) int {
+		if a.InstallOrder != b.InstallOrder {
+			return cmp.Compare(a.InstallOrder, b.InstallOrder)
+		}
+
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
 // applyProviderImage extracts provider manifests for a single provider image and applies them to the cluster.
 func (r *CapiInstallerController) applyProviderImage(ctx context.Context, log logr.Logger, providerImage providerimages.ProviderImageManifests) error {
-	log.Info("reconciling CAPI provider", "name", providerImage.ProviderName)
+	log.Info("reconciling CAPI provider", "name", providerImage.Name)
 
 	reader, err := providerManifestReader(providerImage)
 	if err != nil {
@@ -256,7 +247,7 @@ func (r *CapiInstallerController) applyProviderImage(ctx context.Context, log lo
 		return fmt.Errorf("failed to apply provider components: %w", err)
 	}
 
-	log.Info("finished reconciling CAPI provider", "name", providerImage.ProviderName)
+	log.Info("finished reconciling CAPI provider", "name", providerImage.Name)
 
 	return nil
 }

--- a/pkg/providerimages/providerimages.go
+++ b/pkg/providerimages/providerimages.go
@@ -65,11 +65,11 @@ type ProviderImageManifests struct {
 
 // ProviderMetadata is metadata about a provider image provided in the metadata.yaml file.
 type ProviderMetadata struct {
-	ProviderName     string                `json:"providerName"`
-	ProviderType     string                `json:"providerType"`
-	ProviderVersion  string                `json:"providerVersion"`
-	OCPPlatform      configv1.PlatformType `json:"ocpPlatform,omitempty"`
-	ProviderImageRef string                `json:"providerImageRef,omitempty"`
+	Name         string                `json:"name"`
+	Attributes   map[string]string     `json:"attributes,omitempty"`
+	OCPPlatform  configv1.PlatformType `json:"ocpPlatform,omitempty"`
+	SelfImageRef string                `json:"selfImageRef,omitempty"`
+	InstallOrder int                   `json:"installOrder,omitempty"`
 }
 
 // imageFetcher abstracts fetching container images for testability.
@@ -172,9 +172,9 @@ func readProviderImages(ctx context.Context, log logr.Logger, containerImages []
 		} else {
 			for _, manifest := range result.manifests {
 				log.Info("found provider manifests in container image", "image", result.imageRef,
-					"provider", manifest.ProviderName,
-					"type", manifest.ProviderType,
-					"version", manifest.ProviderVersion,
+					"provider", manifest.Name,
+					"type", manifest.Attributes["type"],
+					"version", manifest.Attributes["version"],
 					"profile", manifest.Profile,
 					"ocpPlatform", manifest.OCPPlatform)
 
@@ -234,7 +234,7 @@ func processProviderImage(ctx context.Context, imageRef, providerImageDir string
 		profileDir := filepath.Join(outputDir, profile.Profile)
 		manifestsPath := filepath.Join(profileDir, manifestsFile)
 
-		contentID, err := writeManifestsWithHash(manifestsPath, profile.Manifests, profile.Metadata.ProviderImageRef, imageRef)
+		contentID, err := writeManifestsWithHash(manifestsPath, profile.Manifests, profile.Metadata.SelfImageRef, imageRef)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
| Old Field | New Location |
|-----------|--------------|
| `ProviderName` | `Name` |
| `ProviderImageRef` | `SelfImageRef` |
| `ProviderType` | `Attributes["type"]` |
| `ProviderVersion` | `Attributes["version"]` |
| `OCPPlatform` | `OCPPlatform` (unchanged) |
| (new) | `InstallOrder` |

Now installs based on `InstallOrder` rather than sorting on type/version.

example update: 

```git
diff --git i/openshift/Makefile w/openshift/Makefile
index 7b2c7fe18..f66b9bf7b 100644
--- i/openshift/Makefile
+++ w/openshift/Makefile
@@ -24,9 +24,10 @@ update-manifests-gen:
 ocp-manifests: $(RELEASE_DIR) ## Builds openshift specific manifests
        # Generate provider manifests.
        cd tools && $(MANIFESTS_GEN) --manifests-path "../capi-operator-manifests" --kustomize-dir="../../openshift" \
-               --provider-name cluster-api-provider-aws \
-               --provider-type infrastructure \
-               --provider-version "${PROVIDER_VERSION}" \
-               --provider-image-ref registry.ci.openshift.org/openshift:aws-cluster-api-controllers \
+               --name cluster-api-provider-aws \
+               --install-order 20\
+               --attribute type=infrastructure \
+               --attribute version="${PROVIDER_VERSION}" \
+               --self-image-ref registry.ci.openshift.org/openshift:aws-cluster-api-controllers \
                --platform AWS \
                --protect-cluster-resource awscluster
diff --git i/openshift/capi-operator-manifests/default/metadata.yaml w/openshift/capi-operator-manifests/default/metadata.yaml
index e5db33a5b..db7cafe1c 100644
--- i/openshift/capi-operator-manifests/default/metadata.yaml
+++ w/openshift/capi-operator-manifests/default/metadata.yaml
@@ -1,5 +1,7 @@
+attributes:
+  type: infrastructure
+  version: v2.10.0
+installOrder: 20
+name: cluster-api-provider-aws
 ocpPlatform: AWS
-providerImageRef: registry.ci.openshift.org/openshift:aws-cluster-api-controllers
-providerName: cluster-api-provider-aws
-providerType: infrastructure
-providerVersion: v2.10.0
+selfImageRef: registry.ci.openshift.org/openshift:aws-cluster-api-controllers
(END)
```